### PR TITLE
daisyUI를 사용하여 공통 버튼 컴포넌트 만들기

### DIFF
--- a/frontend/src/components/common/Button/index.stories.tsx
+++ b/frontend/src/components/common/Button/index.stories.tsx
@@ -1,0 +1,38 @@
+import { StoryFn } from '@storybook/react';
+
+import Button, { ButtonProps } from './index';
+
+export default {
+  title: 'components/common/Button',
+  component: Button
+};
+
+const Template: StoryFn<ButtonProps> = (args) => <Button {...args} />;
+
+export const Default = Template.bind({});
+
+Default.args = {
+  type: 'button',
+  disabled: false,
+  classProp: 'btn-info btn-lg',
+  children: '버튼1',
+  onClick: (e) => {
+    console.log(e);
+  }
+};
+
+export const Primary = Template.bind({});
+
+Primary.args = {
+  type: 'button',
+  disabled: false,
+  children: '버튼2'
+};
+
+export const Ghost = Template.bind({});
+
+Ghost.args = {
+  type: 'button',
+  disabled: false,
+  children: '버튼3'
+};

--- a/frontend/src/components/common/Button/index.stories.tsx
+++ b/frontend/src/components/common/Button/index.stories.tsx
@@ -1,38 +1,52 @@
-import { StoryFn } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 
-import Button, { ButtonProps } from './index';
+import Button from './index';
 
-export default {
+const meta = {
   title: 'components/common/Button',
-  component: Button
-};
+  component: Button,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs'],
+  argTypes: {}
+} satisfies Meta<typeof Button>;
 
-const Template: StoryFn<ButtonProps> = (args) => <Button {...args} />;
+export default meta;
+type Story = StoryObj<typeof meta>;
 
-export const Default = Template.bind({});
-
-Default.args = {
-  type: 'button',
-  disabled: false,
-  classProp: 'btn-info btn-lg',
-  children: '버튼1',
-  onClick: (e) => {
-    console.log(e);
+export const DefaultButton: Story = {
+  args: {
+    type: 'button',
+    disabled: false,
+    classProp: 'w-80 h-14 text-lg bg-black hover:bg-gray-700 text-white',
+    children: '테스트 하러 가기',
+    onClick: (e) => {
+      console.log(e);
+    }
   }
 };
 
-export const Primary = Template.bind({});
-
-Primary.args = {
-  type: 'button',
-  disabled: false,
-  children: '버튼2'
+export const YellowButton: Story = {
+  args: {
+    type: 'button',
+    disabled: false,
+    classProp: 'w-80 h-14 text-lg bg-white hover:bg-yellow-300 text-black',
+    children: '통계 보러 가기',
+    onClick: (e) => {
+      console.log(e);
+    }
+  }
 };
 
-export const Ghost = Template.bind({});
-
-Ghost.args = {
-  type: 'button',
-  disabled: false,
-  children: '버튼3'
+export const BlueButton: Story = {
+  args: {
+    type: 'button',
+    disabled: false,
+    classProp: 'w-80 h-14 text-lg bg-blue-600 text-white hover:bg-blue-700',
+    children: '담벼락 보러 가기',
+    onClick: (e) => {
+      console.log(e);
+    }
+  }
 };

--- a/frontend/src/components/common/Button/index.styles.ts
+++ b/frontend/src/components/common/Button/index.styles.ts
@@ -2,4 +2,7 @@ import tw from 'tailwind-styled-components';
 
 export const CommonButton = tw.button`
     btn
+    rounded-full
+    border-inherit
+    font-bold
 `;

--- a/frontend/src/components/common/Button/index.styles.ts
+++ b/frontend/src/components/common/Button/index.styles.ts
@@ -1,0 +1,5 @@
+import tw from 'tailwind-styled-components';
+
+export const CommonButton = tw.button`
+    btn
+`;

--- a/frontend/src/components/common/Button/index.tsx
+++ b/frontend/src/components/common/Button/index.tsx
@@ -1,0 +1,32 @@
+import { CommonButton } from './index.styles';
+
+export interface ButtonProps {
+  type?: 'button' | 'submit' | 'reset';
+  classProp?: any;
+  onClick?: (e?: React.FormEvent | React.MouseEvent) => void;
+  children?: string | JSX.Element | JSX.Element[];
+  disabled?: boolean;
+}
+
+const Button = ({
+  type = 'button',
+  classProp,
+  onClick,
+  children,
+  disabled = false,
+  ...props
+}: ButtonProps) => {
+  return (
+    <CommonButton
+      {...props}
+      type={type}
+      className={classProp}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      {children}
+    </CommonButton>
+  );
+};
+
+export default Button;


### PR DESCRIPTION
* rebi13/MBTI-Inside#15

```
export interface ButtonProps {
  type?: 'button' | 'submit' | 'reset'; // 버튼 타입. defalut = 'button'
  classProp?: any; // 추가 스타일링을 위한 tailwind 클래스 추가.
  onClick?: (e?: React.FormEvent | React.MouseEvent) => void; // onClick 이벤트
  children?: string | JSX.Element | JSX.Element[]; // 자식 컴포넌트
  disabled?: boolean; // 활성화 여부. default = false
}
```